### PR TITLE
Adopt Apple-inspired style for lyrics page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,43 +4,41 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Song Lyrics</title>
-  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Merriweather:wght@300;400;700&display=swap" rel="stylesheet">
   <style>
     body {
-      font-family: 'Merriweather', serif;
-      background: radial-gradient(circle at top, #3b185f, #1d2671);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background-color: #f5f5f7;
+      color: #1d1d1f;
       margin: 0;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      color: #f1f6ff;
       text-align: center;
-      padding: 20px;
+      padding: 40px 20px;
     }
     .container {
       width: 100%;
-      max-width: 600px;
+      max-width: 800px;
     }
     h1 {
-      font-family: 'Great Vibes', cursive;
-      color: #ffd6e7;
-      margin: 0 0 24px 0;
       font-size: 3rem;
-      text-shadow: 0 0 12px rgba(255, 215, 230, 0.6);
+      font-weight: 600;
+      margin: 0 0 24px 0;
+      color: #1d1d1f;
     }
     #lyrics {
       white-space: pre-wrap; /* preserves formatting like line breaks */
-      font-size: 1.6rem;
-      line-height: 1.8;
+      font-size: 1.25rem;
+      line-height: 1.6;
     }
     @media (max-width: 600px) {
       h1 {
-        font-size: 2.4rem;
+        font-size: 2rem;
       }
       #lyrics {
-        font-size: 1.4rem;
+        font-size: 1rem;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- Simplify the lyrics page with a clean Apple-inspired layout
- Use system font stack and light gray background for an Apple feel
- Streamline typography for headings and lyrics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e9b3fe14832889df8cc9c634ecdf